### PR TITLE
Updated dev console's cypress e2e `selectOrCreateProject(name)` helper to work with #9279

### DIFF
--- a/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
+++ b/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
@@ -72,6 +72,7 @@ const Filter: React.FC<{
     // @ts-ignore
     <MenuInput>
       <TextInput
+        data-test="dropdown-text-filter"
         autoFocus
         value={filterText}
         aria-label={
@@ -323,6 +324,7 @@ const NamespaceMenu: React.FC<{
         onSetFavorite(itemID, !isCurrentFavorite);
       }}
       activeItemId={selected}
+      data-test="namespace-dropdown-menu"
     >
       {/*
         //@ts-ignore */}

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -78,9 +78,8 @@ export const gitPage = {
     cy.get(gitPO.createNewApp)
       .first()
       .click();
-    cy.get(gitPO.newAppName)
-      .clear()
-      .type(newAppName);
+    cy.get(gitPO.newAppName).clear();
+    cy.get(gitPO.newAppName).type(newAppName);
   },
   enterComponentName: (name: string) => {
     app.waitForLoad();

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -163,43 +163,39 @@ export const projectNameSpace = {
 
   selectOrCreateProject: (projectName: string) => {
     projectNameSpace.clickProjectDropdown();
-    cy.get('[role="listbox"]')
-      .find('li')
-      .should('have.length.gt', 5);
+    cy.byTestID('dropdown-menu-item-link').should('have.length.gt', 5);
     // Bug: ODC-6164 - is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
     // cy.testA11y('Create Project modal');
-    cy.byLegacyTestID('dropdown-text-filter').type(projectName);
-    cy.get('[data-test-id="namespace-bar-dropdown"] span.pf-c-dropdown__toggle-text')
+    cy.byTestID('dropdown-text-filter').type(projectName);
+    cy.get('[data-test-id="namespace-bar-dropdown"] span.pf-c-menu-toggle__text')
       .first()
       .as('projectNameSpaceDropdown');
     app.waitForDocumentLoad();
-    cy.get('[role="listbox"]').then(($el) => {
-      if ($el.find('li[role="option"]').length === 0) {
-        cy.byTestDropDownMenu('#CREATE_RESOURCE_ACTION#').click();
-        projectNameSpace.enterProjectName(projectName);
-        cy.byTestID('confirm-action').click();
-        app.waitForLoad();
-      } else {
-        cy.get('[role="listbox"]')
-          .find('li[role="option"]')
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          .each(($ele, index, $list) => {
-            if ($ele.text() === projectName) {
-              cy.get(`[id="${projectName}-link"]`).click();
+    cy.get('[data-test="namespace-dropdown-menu"]')
+      .first()
+      .then(($el) => {
+        if ($el.find('[data-test="dropdown-menu-item-link"]').length === 0) {
+          cy.byTestDropDownMenu('#CREATE_RESOURCE_ACTION#').click();
+          projectNameSpace.enterProjectName(projectName);
+          cy.byTestID('confirm-action').click();
+          app.waitForLoad();
+        } else {
+          cy.get('[data-test="namespace-dropdown-menu"]')
+            .find('[data-test="dropdown-menu-item-link"]')
+            .contains(projectName)
+            .click();
+          cy.get('@projectNameSpaceDropdown').then(($el1) => {
+            if ($el1.text().includes(projectName)) {
+              cy.get('@projectNameSpaceDropdown').should('contain.text', projectName);
+            } else {
+              cy.byTestDropDownMenu('#CREATE_RESOURCE_ACTION#').click();
+              projectNameSpace.enterProjectName(projectName);
+              cy.byTestID('confirm-action').click();
+              app.waitForLoad();
             }
           });
-        cy.get('@projectNameSpaceDropdown').then(($el1) => {
-          if ($el1.text().includes(projectName)) {
-            cy.get('@projectNameSpaceDropdown').should('contain.text', projectName);
-          } else {
-            cy.byTestDropDownMenu('#CREATE_RESOURCE_ACTION#').click();
-            projectNameSpace.enterProjectName(projectName);
-            cy.byTestID('confirm-action').click();
-            app.waitForLoad();
-          }
-        });
-      }
-    });
+        }
+      });
     cy.get('@projectNameSpaceDropdown').should('have.text', `Project: ${projectName}`);
   },
 


### PR DESCRIPTION
- Added `data-test` ids to replace css selectors which are no longer used as component was changed by #9279
- `add-page.feature` e2e test works locally
- `create-from-git.feature` progressed futher

There are two related dev console e2e flake fixes which may need to be merged first in order for this PR to pass CI:
#9793
#9796

